### PR TITLE
Handled HTTP request with no Authentication header #7

### DIFF
--- a/OPCUA_Web_Platform/Auth/RefreshTokenMiddleware.cs
+++ b/OPCUA_Web_Platform/Auth/RefreshTokenMiddleware.cs
@@ -21,6 +21,7 @@ namespace WebPlatform.Auth
             if (context.Request.Path.StartsWithSegments("/api"))
             {
                 string authorization = context.Request.Headers["Authorization"];
+                authorization = (String.IsNullOrEmpty(authorization)) ? "Bearer " : authorization;
                 string token = "empty";
 
                 if (authorization.StartsWith("Bearer ", StringComparison.OrdinalIgnoreCase))

--- a/OPCUA_Web_Platform/appsettings.Development.json
+++ b/OPCUA_Web_Platform/appsettings.Development.json
@@ -15,7 +15,7 @@
       },
       {
         "Name": "UaCppServer Scroppo",
-        "Url": "opc.tcp://192.168.1.101:48010"
+        "Url": "opc.tcp://192.168.1.103:48010"
       },
       {
         "Name": "UaCppServer Marco",


### PR DESCRIPTION
Handled missing Header "Authorization" in HTTP request for authenticated API. This bug is is located in the RefreshTokenMiddleware.